### PR TITLE
fix(server/main): deleteAccount typo

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -229,7 +229,7 @@ lib.callback.register("ps-banking:server:deleteAccount", function(source, accoun
         return false
     end
 
-    MySQL.query.await('DELETE FROM ps_banking_transactions WHERE accountId = ?', { accountId })
+    MySQL.query.await('DELETE FROM ps_banking_transactions WHERE id = ?', { accountId })
     return true
 end)
 


### PR DESCRIPTION
This fixes #10 which is caused by a typo from my previous commit, e74b5e8.