### PR TITLE
feat: dependencies and version checking

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -1,27 +1,35 @@
-fx_version "cerulean"
-game "gta5"
-author "Project Sloth"
-lua54 "yes"
-ui_page "html/index.html"
-version "1.0.2"
--- ui_page "http://localhost:5173"
+fx_version 'cerulean'
+game 'gta5'
+
+name 'ps-banking'
+author 'Project Sloth'
+version '1.0.1'
+
+ui_page 'html/index.html'
+-- ui_page 'http://localhost:5173'
+
+shared_scripts {
+    '@ox_lib/init.lua',
+    'config.lua',
+}
 
 client_scripts {
-    "client/**/*",
+    'client/**/*',
 }
 
 server_scripts {
-    "@oxmysql/lib/MySQL.lua",
-    "server/**/*",
-}
-
-shared_scripts {
-    "@ox_lib/init.lua",
-    "config.lua",
+    '@oxmysql/lib/MySQL.lua',
+    'server/**/*',
 }
 
 files {
-    "html/**/*",
-    "locales/**/*",
+    'html/**/*',
+    'locales/**/*',
 }
 
+dependencies {
+    'ox_lib',
+    'oxmysql'
+}
+
+lua54 'yes'

--- a/server/main.lua
+++ b/server/main.lua
@@ -1,3 +1,6 @@
+lib.versionCheck('Project-Sloth/ps-banking')
+assert(lib.checkDependency('ox_lib', '3.20.0', true))
+
 local framework = nil
 
 if GetResourceState("es_extended") == "started" then


### PR DESCRIPTION
Just some minor QOL things.
- Add `oxmysql` and `ox_lib` as resource dependencies in the manifest
- Add version checking for this repository so people can stay up to date
- Assert the proper ox_lib version (fixes anyone having the same issue as #15)