### PR TITLE
NOT TESTED

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -102,6 +102,14 @@ end)
 -- ATMs
 RegisterNetEvent('ps-banking:client:open:atm')
 AddEventHandler('ps-banking:client:open:atm', function()
+    if Config.OpenAtmOnlyWhenClose then -- Prevent the user trigger this event when is far away from an ATM model. FALSE Default
+         for _, ATM_Models in ipairs(Config.ATM_Models) do
+            local Atm = joaat(ATM_Models)
+            local coords = GetEntityCoords(PlayerPedId())
+            local object = GetClosestObjectOfType(coords.x,coords.y,coords.z,2.5,Atm,false,true,true)
+            if not object then return end -- Didnt find the object, returning.
+         end
+    end
 	Citizen.Wait(100)
     ATM_Animation()
     SendNUIMessage({

--- a/config.lua
+++ b/config.lua
@@ -49,3 +49,5 @@ Config.ATM_Models = {
     "prop_atm_03",
     "prop_fleeca_atm",
 }
+
+Config.OpenAtmOnlyWhenClose = false -- Open the ATM only when the player is close enought


### PR DESCRIPTION
Add a option to open the event only if the player is close to an atm model, preventing executors to open the atm from far away.