### PR TITLE
fix(server/main): deleteAccount sql table

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -232,7 +232,7 @@ lib.callback.register("ps-banking:server:deleteAccount", function(source, accoun
         return false
     end
 
-    MySQL.query.await('DELETE FROM ps_banking_transactions WHERE id = ?', { accountId })
+    MySQL.query.await('DELETE FROM ps_banking_accounts WHERE id = ?', { accountId })
     return true
 end)
 


### PR DESCRIPTION
Fix a wrong table at `ps-banking:server:deleteAccount` callback
